### PR TITLE
ok

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ springboot-env.conf
 ngo-nabarun-test.iml
 /.apt_generated_tests/
 **/allure-results/*
+**/test-output/*

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,14 @@
 			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<!--<dependency>
+			<groupId>io.cucumber</groupId>
+			<artifactId>cucumber-testng</artifactId>
+			<scope>compile</scope>
+		</dependency>-->
+
+
 		<dependency>
 			<groupId>io.cucumber</groupId>
 			<artifactId>cucumber-picocontainer</artifactId>
@@ -164,7 +172,7 @@
 			<version>1.18.42</version>
 			<scope>provided</scope>
 		</dependency>
-			<dependency>
+		<dependency>
 			<groupId>ngo.nabarun</groupId>
 			<artifactId>doppler-java-client</artifactId>
 			<version>1.1.2</version>

--- a/src/test/resources/features/donation.feature
+++ b/src/test/resources/features/donation.feature
@@ -113,7 +113,8 @@ Feature: Donation Management
     Then I click on "Back to Dashboard" link at "Accounts" page
     Then I logout from current session
 
-  @donation @regression @donation02
+  @donation @regression 
+  @donation02
   Scenario: Create and Update Guest Donation (With Event, Cash Payment, Status Transitions)
     ## 1. Authentication & Navigation to Donations
     Then I login with "cashier@nabarun.com" user using Password option


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Tidy Maven dependencies and adjust Cucumber feature tags
<code>⚙️ Configuration changes</code> <code>🧪 Tests</code> <code>🕐 Less than 10 minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>Description</summary>

<br/>

<pre>
• Comment out unused cucumber-testng dependency reference in pom.xml.
• Normalize/adjust donation scenario tags for Cucumber test filtering.
• Minor formatting/indentation cleanup in Maven dependency section.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["Maven build"] --> B["pom.xml"] --> C["Cucumber deps"] --> D["Test runner"] --> E["Feature: donation.feature"] --> F["Scenario tag filters"]
  subgraph Legend
    direction LR
    _cfg["Config file"] ~~~ _test["Test artifact"]
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Remove cucumber-testng block instead of commenting it out</b></summary>

- ➕ Avoids dead/commented configuration drift over time
- ➕ Keeps dependency section clean and unambiguous
- ➖ Loses quick reference if the team expects to re-enable it soon

</details>

<details>
<summary><b>2. Consolidate tags onto one line with consistent ordering</b></summary>

- ➕ More consistent tag style across features
- ➕ Easier grep/search for scenario groupings
- ➖ May conflict with a team convention to separate tags per line for readability

</details>

**Recommendation:** If cucumber-testng is truly not used, prefer removing the commented dependency entirely to prevent configuration rot. Otherwise, the current approach is acceptable as a short-term breadcrumb. For tags, ensure the new formatting still matches how the test runner selects tags (some setups assume a single-line tag block, though Cucumber generally treats multi-line tags equivalently).

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Tests</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>donation.feature</strong> <code>Split donation scenario tags across lines</code> <code>+2/-1</code></summary>

<br/>

>Split donation scenario tags across lines
>
><pre>
>• Reformats the scenario tags by moving @donation02 onto its own line while keeping @donation and @regression. This affects how the scenario is grouped/selected when running tag-filtered Cucumber suites.
></pre>
>
><a href='https://github.com/nabarun-ngo/ngo-nabarun-test/pull/35/files#diff-4f1a57a264a438ff323a0a4935b7e6940902738bf93b1ad830e2c58e9533da27'>src/test/resources/features/donation.feature</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Other</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>pom.xml</strong> <code>Adjust dependency section and add commented cucumber-testng reference</code> <code>+9/-1</code></summary>

<br/>

>Adjust dependency section and add commented cucumber-testng reference
>
><pre>
>• Adds a commented-out cucumber-testng dependency block (likely as a reference/placeholder). Also fixes indentation/alignment around an existing dependency entry, without changing versions or artifacts.
></pre>
>
><a href='https://github.com/nabarun-ngo/ngo-nabarun-test/pull/35/files#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8'>pom.xml</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>